### PR TITLE
Exclude scattering region from fit

### DIFF
--- a/src/pymca_zocalo/internals.py
+++ b/src/pymca_zocalo/internals.py
@@ -430,7 +430,7 @@ def run_auto_pymca(
         f.write(results_txt)
 
     pymca_output = parse_raw_fluoro(
-        channel_energy, channel_counts, beam_energy, fitted_peaks, cutoff_channel
+        channel_energy, channel_counts, fitted_peaks, cutoff_channel
     )
 
     plot_output_file = src_data_dir / f"{filename_stem}.png"

--- a/src/pymca_zocalo/internals.py
+++ b/src/pymca_zocalo/internals.py
@@ -200,7 +200,7 @@ def parse_elements(cutoff_energy, beamline):
     def _check_edge(symbol, edge):
         Z = xrl.SymbolToAtomicNumber(symbol)
         shell = edge_mapper[edge]
-        return float(cutoff_energy) > xrl.EdgeEnergy(Z, shell) * 1000.0
+        return float(cutoff_energy) > xrl.LineEnergy(Z, shell) * 1000.0
 
     if beamline == "i23":
         elements.update(i23_elements)

--- a/src/pymca_zocalo/internals.py
+++ b/src/pymca_zocalo/internals.py
@@ -412,10 +412,11 @@ def run_auto_pymca(
     )
     if cutoff_channel < fit_xmax:
         config_dict["fit"]["xmax"] = cutoff_channel
+    config_dict["fit"]["scatterflag"] = 0
     config_dict.write(cfg_file)
 
     if not cfg_file.exists():
-        raise FileNotFoundError(f"File {cfg_file} does not exist")
+        raise FileNotFoundError(f"Failed to write config file to {cfg_file}")
 
     # Create a batch fit object
     pymca_batch_fit_obj = McaAdvancedFitBatch.McaAdvancedFitBatch(

--- a/src/pymca_zocalo/internals.py
+++ b/src/pymca_zocalo/internals.py
@@ -424,8 +424,12 @@ def run_auto_pymca(
     fitted_peaks = parse_spec_fit(fit_data_file)
 
     results_file = output_dir / f"{filename_stem}.results.dat"
-    results_txt = [f"{peak[0]} {peak[1]} {peak[2]}" for peak in fitted_peaks]
-    results_txt = "\n".join(results_txt)
+    header_txt = [
+        f"# COMPTON_CUTOFF(eV): {cutoff_energy:.2f}",
+        "# COLUMN_HEADERS: Element-Edge Counts Sigma",
+    ]
+    results_txt = [f"{peak[0]} {peak[1]:.2f} {peak[2]:.2f}" for peak in fitted_peaks]
+    results_txt = "\n".join(header_txt + results_txt)
     with open(results_file, "w") as f:
         f.write(results_txt)
 

--- a/src/pymca_zocalo/internals.py
+++ b/src/pymca_zocalo/internals.py
@@ -13,7 +13,7 @@ from PyMca5.PyMca import McaAdvancedFitBatch
 from PyMca5.PyMcaIO import ConfigDict
 
 
-def parse_raw_fluoro(channel_energy, channel_counts, peaks, cutoff_channel):
+def parse_raw_fluoro(channel_counts, peaks, cutoff_channel):
     """Calculate total and background counts from raw spectrum, then
     return results as formatted text for top 5 fitted peaks if there
     is sufficient signal above the background"""
@@ -28,8 +28,6 @@ def parse_raw_fluoro(channel_energy, channel_counts, peaks, cutoff_channel):
         "L": xrl.L3M5_LINE,
     }
     # Get total counts and background counts up to a cutoff energy
-    if not cutoff_channel:
-        cutoff_channel = len(channel_energy)
     total_count = np.sum(channel_counts[0:cutoff_channel])
     # Maximum of 2 counts per channel contribute to background
     background_count = np.sum(np.minimum(2, channel_counts[0:cutoff_channel]))
@@ -433,9 +431,7 @@ def run_auto_pymca(
     with open(results_file, "w") as f:
         f.write(results_txt)
 
-    pymca_output = parse_raw_fluoro(
-        channel_energy, channel_counts, fitted_peaks, cutoff_channel
-    )
+    pymca_output = parse_raw_fluoro(channel_counts, fitted_peaks, cutoff_channel)
 
     plot_output_file = src_data_dir / f"{filename_stem}.png"
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pymca_zocalo.internals as internals
-from pytest import raises
 
 
 def test_GIVEN_examplar_data_in_h5file_WHEN_run_auto_pymca_called_THEN_produces_expected_files(
@@ -112,10 +111,9 @@ def test_GIVEN_examplar_data_in_dat_format_WHEN_run_auto_pymca_called_THEN_produ
 
 
 def test_GIVEN_fitted_peaks_WHEN_call_parse_raw_fluoro_THEN_get_expected_output():
-    channel_energy = np.arange(0, 6, dtype=float)
     channel_counts = np.array([250.0, 1.1, 250.0, 250.0, 250.0])
-    offset = 1.0
-    beam_energy = 5.0
+    cutoff_channel = 1600
+
     peaks = [
         ("Se-K", 500.0, 40.0),
         ("Fe-K", 250.0, 20.0),
@@ -125,9 +123,7 @@ def test_GIVEN_fitted_peaks_WHEN_call_parse_raw_fluoro_THEN_get_expected_output(
         ("Hg-L", 10.0, 8.0),
     ]
 
-    output_txt = internals.parse_raw_fluoro(
-        channel_energy, channel_counts, beam_energy, peaks, offset
-    )
+    output_txt = internals.parse_raw_fluoro(channel_counts, peaks, cutoff_channel)
 
     assert (
         "Element\tCounts\t%age\tExpected Emission Energies" in output_txt
@@ -139,10 +135,8 @@ def test_GIVEN_fitted_peaks_WHEN_call_parse_raw_fluoro_THEN_get_expected_output(
 
 
 def test_GIVEN_low_counts_WHEN_call_parse_raw_fluoro_THEN_output_warning():
-    channel_energy = np.arange(0, 6, dtype=float)
     channel_counts = np.array([4.0, 1.1, 4.0, 4.0, 4.0])
-    offset = 1.0
-    beam_energy = 5.0
+    cutoff_channel = 1600
     peaks = [
         ("Se-K", 500.0, 40.0),
         ("Fe-K", 250.0, 20.0),
@@ -152,9 +146,7 @@ def test_GIVEN_low_counts_WHEN_call_parse_raw_fluoro_THEN_output_warning():
         ("Hg-L", 10.0, 8.0),
     ]
 
-    output_txt = internals.parse_raw_fluoro(
-        channel_energy, channel_counts, beam_energy, peaks, offset
-    )
+    output_txt = internals.parse_raw_fluoro(channel_counts, peaks, cutoff_channel)
     assert (
         "No fluorescence peaks detected" in output_txt
     ), "No peaks warning message not written"
@@ -164,37 +156,13 @@ def test_GIVEN_low_counts_WHEN_call_parse_raw_fluoro_THEN_output_warning():
 
 
 def test_GIVEN_no_peaks_WHEN_call_parse_raw_fluoro_THEN_output_warning():
-    channel_energy = np.arange(0, 6, dtype=float)
     channel_counts = np.array([250.0, 1.1, 250.0, 250.0, 250.0])
-    offset = 1.0
-    beam_energy = 5.0
+    cutoff_channel = 1600
     peaks = []
 
-    output_txt = internals.parse_raw_fluoro(
-        channel_energy, channel_counts, beam_energy, peaks, offset
-    )
+    output_txt = internals.parse_raw_fluoro(channel_counts, peaks, cutoff_channel)
     assert (
         "Counts found but no peaks of select elements fitted" in output_txt
     ), "Warning message not written"
     assert "Counts (total): 1001.1" in output_txt, "Incorrect total counts"
     assert "(background): 9.1" in output_txt, "Incorrect background counts"
-
-
-def test_GIVEN_unsuitable_cutoff_WHEN_call_parse_raw_fluoro_THEN_raise_ValueError():
-    channel_energy = np.arange(0, 6, dtype=float)
-    channel_counts = np.array([250.0, 1.1, 250.0, 250.0, 250.0])
-    offset = 6.0
-    beam_energy = 5.0
-    peaks = [
-        ("Se-K", 500.0, 40.0),
-        ("Fe-K", 250.0, 20.0),
-        ("Pb-L", 50.0, 10.0),
-        ("Au-L", 40.0, 15.0),
-        ("Pt-L", 30.0, 14.0),
-        ("Hg-L", 10.0, 8.0),
-    ]
-
-    with raises(ValueError):
-        internals.parse_raw_fluoro(
-            channel_energy, channel_counts, beam_energy, peaks, offset
-        )


### PR DESCRIPTION
PyMCA does not fit scatter peaks well and a knock-on effect is that this can compromise the quality of the fit for emission peaks. Solution for this is to cut the scatter peak region out of the fit and set the scatter_flag to 0 in the config file (to instruct PyMCA not to fit the scatter peaks).

To ensure that the scatter region is cut out of the spectrum, a beam energy specific cutoff is applied, which is the theoretical Compton edge (photon energy for a Compton scattering angle of 180°) - 500 eV to account for any broadening effects. 

To propagate these changes to SynchWeb (see https://jira.diamond.ac.uk/browse/LIMS-2055), the Compton cutoff will need to be included in the results file. This has been included as a file header. As an addition, column headers have also been added to make the results file more readable. 